### PR TITLE
Move CPU-intensive zip task to worker thread

### DIFF
--- a/express/zip.js
+++ b/express/zip.js
@@ -1,0 +1,26 @@
+const { Worker, isMainThread, workerData } = require("worker_threads");
+const AdmZip = require("adm-zip");
+
+if (isMainThread) {
+    module.exports = function zipThread(folder, output) {
+        return new Promise((resolve, reject) => {
+            const workerThread = new Worker(__filename, {
+                workerData: { folder, output }
+            });
+            workerThread.on("message", resolve);
+            workerThread.on("error", reject);
+            workerThread.on("exit", code => {
+                if (code === 0) {
+                    resolve(null);
+                } else {
+                    reject(new Error(`Worker thread exited with code ${code}`));
+                }
+            });
+        });
+    }
+} else {
+    const { folder, output } = workerData;
+    const zip = new AdmZip();
+    zip.addLocalFolder(folder);
+    zip.writeZip(output);
+}


### PR DESCRIPTION
Fix: event loop is no longer blocked and server will remain responsive when a download is requested.

Caveat: multiple requests for the same result dataset may have unexpected results if the dataset is mutated somewhere in the middle. 